### PR TITLE
Update R to latest available version (3.5.0)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rocker/r-ver:3.4.3
+FROM rocker/r-ver:3.5.0
 
 ENV PATH /usr/local/lib/R/bin/:$PATH
 ENV R_HOME /usr/local/lib/R


### PR DESCRIPTION
Someone wanted it in ticket. I think we can update it.

Local build looks fine:

```
...
...

** testing if installed package can be loaded
* DONE (tidyverse)
* installing *source* package ‘caret’ ...
** package ‘caret’ successfully unpacked and MD5 sums checked
** libs
make[1]: Entering directory '/tmp/Rtmppf7Dbw/R.INSTALL110846e91aaa/caret/src'
gcc -I"/usr/local/lib/R/include" -DNDEBUG   -I/usr/local/include   -fpic  -g -O2 -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c caret.c -o caret.o
gcc -shared -L/usr/local/lib/R/lib -L/usr/local/lib -o caret.so caret.o -L/usr/local/lib/R/lib -lR
make[1]: Leaving directory '/tmp/Rtmppf7Dbw/R.INSTALL110846e91aaa/caret/src'
installing to /usr/local/lib/R/site-library/caret/libs
** R
** data
** inst
** byte-compile and prepare package for lazy loading
** help
*** installing help indices
** building package indices
** installing vignettes
** testing if installed package can be loaded
* DONE (caret)

The downloaded source packages are in
	‘/tmp/Rtmp9OpxKL/make_packages’
Removing intermediate container 614d1de0342e
 ---> 8fed0bf87273
Successfully built 8fed0bf87273
Successfully tagged keboola/docker-custom-r:latest
```