### PR TITLE
add prophet to default installed packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/keboola/docker-base-r:4.0.2
+FROM quay.io/keboola/docker-base-r:4.0.3
 
 ENV PATH /usr/local/lib/R/bin/:$PATH
 ENV R_HOME /usr/local/lib/R

--- a/init-1.R
+++ b/init-1.R
@@ -12,7 +12,7 @@ withCallingHandlers(install.packages(
         'lattice', 
         'MASS', 'mda', 'mgcv', 'mlbench',
         'nlme', 'nnet', 
-        'party', 'pamr', 'pls', 'pROC', 'proxy',
+        'party', 'pamr', 'pls', 'pROC', 'prophet', 'proxy',
         'randomForest', 'RANN', 'rgdal',
         'spls', 'sqldf', 'subselect', 'superpc',
         'testthat', 'timeDate', 'tree',


### PR DESCRIPTION
Because it's a beast, it often breaks when trying to install on sandbox creation so including it in the base image may be helpful.