### PR TITLE
PS-1986 Upgrade pip after install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rocker/r-ver:3.6.2
+FROM rocker/r-ver:3.6.3
 
 ENV PATH /usr/local/lib/R/bin/:$PATH
 ENV R_HOME /usr/local/lib/R
@@ -47,6 +47,8 @@ RUN apt-get update \
 WORKDIR /tmp
 
 COPY init.R /tmp/init.R
+
+RUN python3 -m pip install --upgrade pip
 
 # Install some commonly used R packages
 RUN R CMD javareconf \

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-# Keboola Custom R
-[![Build Status](https://travis-ci.com/keboola/docker-custom-r.svg?branch=master)](https://travis-ci.com/keboola/docker-custom-r)
+# Docker Image for R Sandboxes and Transformations
 
 Base image for R components. See [documentation](https://developers.keboola.com/extend/) for more details about building components for KBC.
 

--- a/init.R
+++ b/init.R
@@ -12,9 +12,9 @@ withCallingHandlers(install.packages(
         'lattice',
         'MASS', 'mda', 'mgcv', 'mlbench',
         'nlme', 'nnet',
-        'party', 'pamr', 'pls', 'pROC', 'prophet', 'proxy', 'purrr',
+        'party', 'pamr', 'pls', 'pROC', 'proxy', 'purrr',
         'randomForest', 'RANN', 'RcppArmadillo', 'rgdal', 'rJava', 'RJDBC', 'rversions',
-        'spls', 'sqldf', 'superpc',
+        'spls', 'sqldf', 'subselect', 'superpc',
         'testthat', 'tidyverse', 'timeDate', 'tree',
         'zoo'
     ),
@@ -24,11 +24,8 @@ withCallingHandlers(install.packages(
     Ncpus = 2
 ), warning = function(w) stop(w))
 
-# tmp: the package subselect isn't available on MRAN for r 3.6.2, so we'll need to get it from a different repo
-withCallingHandlers(install.packages(
-    c("subselect"),
-    repos=c("https://cloud.r-project.org")
-), warning = function(w) stop(w))
+# prophet cannot be downloaded from CRAN repository
+devtools::install_github('facebook/prophet', ref='0.6', subdir='/R')
 
 # install the R application
-devtools::install_github('keboola/r-docker-application', ref = "2.0.2")
+devtools::install_github('keboola/r-docker-application', ref='2.0.2')


### PR DESCRIPTION
So the new release also installed pip 18. 😕

![image](https://user-images.githubusercontent.com/215660/112539200-fc34a080-8db0-11eb-8e4d-a55eaee31cc2.png)

But I see we have the pip upgrade in docker-custom-python: https://github.com/keboola/docker-custom-r/blob/master/Dockerfile#L39 so it should help here too. 🙂