### PR TITLE
PST-2118: R 4.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# 4.4.1
+
+- package `rgdal` removed as it's deprecated. It's functionality should be covered by `sf` or `terra` package
+- package `subselect` removed, not compatible with R version 4.4.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ RUN apt-get update \
         libcairo2-dev \
         libcurl4-openssl-dev \
         libgdal-dev \
+        libgit2-dev  \
         libcgal-dev \
         libxext-dev \
         libglu1-mesa-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rocker/r-ver:4.2.2
+FROM rocker/r-ver:4.4.1
 
 ENV PATH /usr/local/lib/R/bin/:$PATH
 ENV R_HOME /usr/local/lib/R

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
 # Docker Image for R Sandboxes and Transformations
 
 Base image for R components. See [documentation](https://developers.keboola.com/extend/) for more details about building components for KBC.
-

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,7 +31,7 @@ steps:
       tags: |
         latest
         $(imageTag)
-  
+
   - script: |
       docker login -u="$(QUAY_USERNAME)" -p="$(QUAY_PASSWORD)" quay.io
       docker tag keboola.azurecr.io/docker-custom-r quay.io/$(KBC_APP_REPOSITORY):$(imageTag)
@@ -41,10 +41,10 @@ steps:
       docker push quay.io/$(KBC_APP_REPOSITORY):latest
     condition: eq(variables['isTagBuild'], 'true')
     displayName: 'Push latest to quay.io'
-    
+
   - task: Docker@2
     inputs:
-      containerRegistry: 'keboola-4338'
+      containerRegistry: 'Keboola ACR'
       repository: 'docker-custom-r'
       command: 'push'
       tags: '$(imageTag)'

--- a/init.R
+++ b/init.R
@@ -1,8 +1,9 @@
 #install some commonly used packages
 withCallingHandlers(install.packages(
     c(
-        'caret', 'caTools', 'ChannelAttribution', 'Cubist',
-        'data.table', 'data.tree', 'DBI', 'doParallel', 'dplyr',
+        'BTYD',
+        'car', 'caret', 'caTools', 'ChannelAttribution', 'Cubist',
+        'data.table', 'data.tree', 'DBI', 'devtools', 'doParallel', 'dplyr',
         'earth', 'ellipse', 'e1071',
         'forecast', 'foreach', 'fs',
         'gam', 'gbm', 'gdata', 'ggplot2', 'googleCloudStorageR', 'gsl',
@@ -16,7 +17,7 @@ withCallingHandlers(install.packages(
         'party', 'pamr', 'pdfsearch', 'pdftools', 'plotly', 'pls', 'pROC', 'prophet', 'proxy', 'purrr',
         'randomForest', 'RANN', 'reshape', 'RcppArmadillo', 'rJava', 'RJDBC', 'rversions',
         'sf', 'spls', 'splitstackshape', 'sqldf', 'staplr', 'stringdist', 'stringi', 'stringr', 'superpc',
-        'testthat', 'tidyxl', 'timeDate', 'tree',
+        'testthat', 'tidyverse', 'tidyxl', 'timeDate', 'tree',
         'unpivotr',
         'zoo'
     ),
@@ -27,4 +28,4 @@ withCallingHandlers(install.packages(
 ), warning = function(w) stop(w))
 
 # install the R application
-#devtools::install_github('keboola/r-docker-application', ref='2.0.2')
+devtools::install_github('keboola/r-docker-application', ref='2.0.2')

--- a/init.R
+++ b/init.R
@@ -1,9 +1,8 @@
 #install some commonly used packages
 withCallingHandlers(install.packages(
     c(
-        'BTYD',
-        'car', 'caret', 'caTools', 'ChannelAttribution', 'Cubist',
-        'data.table', 'data.tree', 'DBI', 'devtools', 'doParallel', 'dplyr',
+        'caret', 'caTools', 'ChannelAttribution', 'Cubist',
+        'data.table', 'data.tree', 'DBI', 'doParallel', 'dplyr',
         'earth', 'ellipse', 'e1071',
         'forecast', 'foreach', 'fs',
         'gam', 'gbm', 'gdata', 'ggplot2', 'googleCloudStorageR', 'gsl',
@@ -15,9 +14,9 @@ withCallingHandlers(install.packages(
         'magrittr', 'MASS', 'mda', 'mgcv', 'mlbench',
         'nlme', 'nnet',
         'party', 'pamr', 'pdfsearch', 'pdftools', 'plotly', 'pls', 'pROC', 'prophet', 'proxy', 'purrr',
-        'randomForest', 'RANN', 'reshape', 'RcppArmadillo', 'rgdal', 'rJava', 'RJDBC', 'rversions',
-        'sf', 'spls', 'splitstackshape', 'sqldf', 'staplr', 'stringdist', 'stringi', 'stringr', 'subselect', 'superpc',
-        'testthat', 'tidyverse', 'tidyxl', 'timeDate', 'tree',
+        'randomForest', 'RANN', 'reshape', 'RcppArmadillo', 'rJava', 'RJDBC', 'rversions',
+        'sf', 'spls', 'splitstackshape', 'sqldf', 'staplr', 'stringdist', 'stringi', 'stringr', 'superpc',
+        'testthat', 'tidyxl', 'timeDate', 'tree',
         'unpivotr',
         'zoo'
     ),
@@ -28,4 +27,4 @@ withCallingHandlers(install.packages(
 ), warning = function(w) stop(w))
 
 # install the R application
-devtools::install_github('keboola/r-docker-application', ref='2.0.2')
+#devtools::install_github('keboola/r-docker-application', ref='2.0.2')


### PR DESCRIPTION
[PST-2118](https://keboola.atlassian.net/browse/PST-2118)

Update to R version 4.4.1:

- package `rgdal` removed as it's deprecated. It's functionality should be covered by `sf` package
- package `subselect` removed, not compatible with R version 4.4.1

[PST-2118]: https://keboola.atlassian.net/browse/PST-2118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ